### PR TITLE
lightline: Fix normal.warning readability

### DIFF
--- a/autoload/lightline/colorscheme/gruvbox.vim
+++ b/autoload/lightline/colorscheme/gruvbox.vim
@@ -50,7 +50,7 @@ if exists('g:lightline')
   let s:p.tabline.middle = [ [ s:bg0, s:bg4 ] ]
   let s:p.tabline.right = [ [ s:bg0, s:orange ] ]
   let s:p.normal.error = [ [ s:bg0, s:orange ] ]
-  let s:p.normal.warning = [ [ s:bg2, s:yellow ] ]
+  let s:p.normal.warning = [ [ s:bg0, s:yellow ] ]
 
   let g:lightline#colorscheme#gruvbox#palette = lightline#colorscheme#flatten(s:p)
 endif


### PR DESCRIPTION
Not sure if this is the right solution, but seems alright ([lightline-ale](https://github.com/maximbaz/lightline-ale) pictured):

Before:
![Light before](https://user-images.githubusercontent.com/3533182/80784276-f8ca7200-8b6b-11ea-8d31-441980e9fbf7.png)
![Dark before](https://user-images.githubusercontent.com/3533182/80784278-fb2ccc00-8b6b-11ea-8b34-0a6de3918aad.png)

After:
![Light after](https://user-images.githubusercontent.com/3533182/80784263-f23bfa80-8b6b-11ea-8c08-9a4b1bd0a9f9.png)
![Dark after](https://user-images.githubusercontent.com/3533182/80784282-fe27bc80-8b6b-11ea-9714-caffe4f1db67.png)
